### PR TITLE
Added support for UNSIGNED with TinyInt

### DIFF
--- a/TinyInt.php
+++ b/TinyInt.php
@@ -9,7 +9,7 @@ class TinyInt extends Type {
 	const TINYINT = 'tinyint';
 	
 	public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform) {
-		return 'TINYINT';
+		return 'TINYINT' . ( ! empty($fieldDeclaration['unsigned']) ? ' UNSIGNED' : '');
 	}
 	
 	public function getName() {


### PR DESCRIPTION
This adds support for setting the `unsigned` option with TinyInt. It uses the same logic from the [MySqlPlatform](https://github.com/doctrine/dbal/blob/b0726e7aab01080fc385599a88491a0ccdbd9417/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php#L942)

```
	/**
	 * @ORM\Column(type="tinyint", options={"unsigned"=true})
	 * @var int
	 */
	private $tinyint;
```