### PR TITLE
Update doctrine/dbal requirement to ^4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine TinyInt
 
-An tinyint type for Doctrine MYSQL
+A tinyint type for Doctrine MYSQL
 
 ## Installation:
 
@@ -25,17 +25,14 @@ doctrine:
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use GollumSF\Doctrine\TinyInt;
 
-/**
- * @ORM\Table()
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'entities')]
 class Entity {
 	
-	/**
-	 * @ORM\Column(type="tinyint")
-	 * @var int
-	 */
-	private $tinyint;
+	#[Column(name: 'tinyint', type: TinyInt::TINYINT)]
+	private int $tinyint;
 	
 	/////////
 	// ... //

--- a/TinyInt.php
+++ b/TinyInt.php
@@ -5,22 +5,20 @@ namespace GollumSF\Doctrine;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
-class TinyInt extends Type {
-	const TINYINT = 'tinyint';
-	
+class TinyInt extends Type
+{
+	public const TINYINT = 'tinyint';
+
 	/**
-	 * @param array $fieldDeclaration
-	 * @param AbstractPlatform $platform
-	 * @return string
+	 * @inheritDoc
 	 */
-	public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform) {
-		return 'TINYINT' . ( ! empty($fieldDeclaration['unsigned']) ? ' UNSIGNED' : '');
+	public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+	{
+		return 'TINYINT' . (!empty($column['unsigned']) ? ' UNSIGNED' : '');
 	}
-	
-	/**
-	 * @return string
-	 */
-	public function getName() {
+
+	public function getName(): string
+	{
 		return self::TINYINT;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name" : "gollumsf/doctrine-tinyint",
 	"type" : "library",
-	"description" : "An tinyint type for Doctrine MYSQL",
+	"description" : "A tinyint type for Doctrine MYSQL",
 	"keywords" : [
 		"tinyint",
 		"doctrine",
@@ -20,13 +20,12 @@
 	},
 	"minimum-stability": "dev",
 	"require" : {
-		"php" : ">=7.0",
-		"doctrine/dbal": "^2|^3"
+		"php" : ">=8",
+		"doctrine/dbal": "^4"
 	},
 	"autoload" : {
-		"psr-0" : {
-			"GollumSF\\Doctrine" : ""
+		"psr-4" : {
+			"GollumSF\\Doctrine\\" : ""
 		}
-	},
-	"target-dir" : "GollumSF/Doctrine"
+	}
 }


### PR DESCRIPTION
**Important Changes:**
- Updated doctrine/dbal to version ^4 for compatibility with doctrine/orm ^3.
- Modified TinyInt class methods getSQLDeclaration and getName to include explicit return types, aligning with doctrine/dbal ^4's interface.

**Recommendation:**
- Propose a major version release to reflect the dependency upgrade and adherence to SemVer, given the changes' impact on compatibility.