### PR TITLE
Added DC2Type into column comment

### DIFF
--- a/TinyInt.php
+++ b/TinyInt.php
@@ -14,7 +14,7 @@ class TinyInt extends Type
 	 */
 	public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
 	{
-		return 'TINYINT' . (!empty($column['unsigned']) ? ' UNSIGNED' : '');
+		return 'TINYINT' . (!empty($column['unsigned']) ? ' UNSIGNED' : '') . ' COMMENT \'(DC2Type:tinyint)\'';
 	}
 
 	public function getName(): string


### PR DESCRIPTION
Added DC2Type into column comment. It allows doctrine:migrations:diff do not generate a mistake migration.